### PR TITLE
Wrong EventManager is injected when dbal.debug = true

### DIFF
--- a/tests/cases/DI/DbalExtensionTest.php
+++ b/tests/cases/DI/DbalExtensionTest.php
@@ -8,6 +8,7 @@ use Nette\DI\Compiler;
 use Nette\DI\Container;
 use Nette\DI\ContainerLoader;
 use Nettrine\DBAL\DI\DbalExtension;
+use Nettrine\DBAL\Events\DebugEventManager;
 use Tests\Nettrine\DBAL\TestCase;
 
 final class DbalExtensionTest extends TestCase
@@ -68,6 +69,27 @@ final class DbalExtensionTest extends TestCase
 				'firstname' => 'Sam',
 			],
 		], $select->fetchAll());
+	}
+
+
+	/**
+	 * @return void
+	 */
+	public function testDebugMode(): void
+	{
+		$loader = new ContainerLoader(TEMP_PATH, TRUE);
+		$class = $loader->load(function (Compiler $compiler): void {
+			$compiler->addExtension('dbal', new DbalExtension());
+			$compiler->addConfig(['dbal' => ['debug' => TRUE]]);
+		}, '1b');
+
+		/** @var Container $container */
+		$container = new $class();
+
+		/** @var Connection $connection */
+		$connection = $container->getByType(Connection::class);
+
+		$this->assertInstanceOf(DebugEventManager::class, $connection->getEventManager());
 	}
 
 }


### PR DESCRIPTION
## TL;DR

Wrong `EventManager` is injected when `dbal.debug = true`. In combination with `nettrine/orm` it causes `EventManager` mismatch in `Connection` and `EntityManager`.

---

## Detailed Report

I'd like to see SQL queries on my Tracy panel. However after setting `dbal.debug` to `true`, I'm getting 

```
Doctrine\ORM\ORMException: Cannot use different EventManager instances for EntityManager and Connection.
```

### Steps to reproduce this bug:

#### 1. Prepare the environment

```
composer create-project nette/web-project test
cd test
# increase PHP version in composer.json to >= 7.1 (7.1.16 in my case)
composer update

composer require contributte/console
# create bin/console as stated in documentation - https://github.com/contributte/console/blob/master/.docs/README.md#entrypoint

composer require nettrine/orm
mkdir app/Entity
```

#### 2. Minimal configuration

Add following to `app/config/config.neon`:

```
extensions:
	console: Contributte\Console\DI\ConsoleExtension

	dbal: Nettrine\DBAL\DI\DbalExtension

	orm: Nettrine\ORM\DI\OrmExtension
	orm.annotations: Nettrine\ORM\DI\OrmAnnotationsExtension
	orm.console: Nettrine\ORM\DI\OrmConsoleExtension

dbal:
	debug: true

orm.annotations:
	paths:
		- %appDir%/Entity
```

#### 3. Run `./bin/console`

You should get

```
Doctrine\ORM\ORMException: Cannot use different EventManager instances for EntityManager and Connection.
```

---

### This fix

Autowiring of `EventManager` is moved right after the default definition.

For `Connection`, the `EventManager` itself is autowired just like in `nettrine/orm` - [see here](https://github.com/nettrine/orm/blob/565e5634ef58a72fcd3d4bd9db24adea311c23b8/src/DI/OrmExtension.php#L141).
