### PR TITLE
ConnectionHelper alias

### DIFF
--- a/src/DI/DbalConsoleExtension.php
+++ b/src/DI/DbalConsoleExtension.php
@@ -61,7 +61,7 @@ class DbalConsoleExtension extends CompilerExtension
 
 		// Register helpers
 		$connectionHelper = $this->prefix('@connectionHelper');
-		$application->addSetup(new Statement('$service->getHelperSet()->set(?)', [$connectionHelper]));
+		$application->addSetup(new Statement('$service->getHelperSet()->set(?, ?)', [$connectionHelper, 'db']));
 	}
 
 }


### PR DESCRIPTION
Current `^2.6` version of `ImportCommand` in `doctrine/dbal` requires the connection helper to be aliased with `"db"`:

https://github.com/doctrine/dbal/blob/3591db5a402bbcf255e35441d0f150fde44c64ba/lib/Doctrine/DBAL/Tools/Console/Command/ImportCommand.php#L62-L65

`Nettrine\DBAL\DI\DbalConsoleExtension` however does not do that - it only registers the helper without any alias:

https://github.com/nettrine/dbal/blob/8e3cce06f102efc62e5c40cc394b09563f57944d/src/DI/DbalConsoleExtension.php#L62-L64

---

This causes the usage of `dbal:import` command impossible leading it to error

```
The helper "db" is not defined.
```

---

This PR adds the alias.
