### PR TITLE
Fix incompatibility with contributte/console

### DIFF
--- a/src/DI/DbalConsoleExtension.php
+++ b/src/DI/DbalConsoleExtension.php
@@ -35,14 +35,17 @@ class DbalConsoleExtension extends CompilerExtension
 		//Commands
 		$builder->addDefinition($this->prefix('importCommand'))
 			->setFactory(ImportCommand::class)
+			->addTag('console.command', 'dbal:import')
 			->setAutowired(false);
 
 		$builder->addDefinition($this->prefix('reservedWordsCommand'))
 			->setFactory(ReservedWordsCommand::class)
+			->addTag('console.command', 'dbal:reserved-words')
 			->setAutowired(false);
 
 		$builder->addDefinition($this->prefix('runSqlCommand'))
 			->setFactory(RunSqlCommand::class)
+			->addTag('console.command', 'dbal:run-sql')
 			->setAutowired(false);
 	}
 


### PR DESCRIPTION
It is not possible to use contributte/console in lazy mode. If you try, you will get this error:
`Nette\DI\ServiceCreationException: Command "Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand" missing tag "console.command[name]" or variable "$defaultName". in ...`