### PR TITLE
DbalConsoleExtension: accept %consoleMode% in constructor

### DIFF
--- a/src/DI/DbalConsoleExtension.php
+++ b/src/DI/DbalConsoleExtension.php
@@ -13,6 +13,14 @@ use Nette\DI\Statement;
 class DbalConsoleExtension extends CompilerExtension
 {
 
+	/** @var bool */
+	private $cliMode;
+
+	public function __construct(?bool $cliMode = null)
+	{
+		$this->cliMode = $cliMode ?? PHP_SAPI === 'cli';
+	}
+
 	/**
 	 * Register services
 	 */
@@ -23,7 +31,9 @@ class DbalConsoleExtension extends CompilerExtension
 		}
 
 		// Skip if it's not CLI mode
-		if (PHP_SAPI !== 'cli') return;
+		if (!$this->cliMode) {
+			return;
+		}
 
 		$builder = $this->getContainerBuilder();
 
@@ -55,7 +65,9 @@ class DbalConsoleExtension extends CompilerExtension
 	public function beforeCompile(): void
 	{
 		// Skip if it's not CLI mode
-		if (PHP_SAPI !== 'cli') return;
+		if (!$this->cliMode) {
+			return;
+		}
 
 		$builder = $this->getContainerBuilder();
 


### PR DESCRIPTION
The extension in contributte/console requires `%consoleMode%` in constructor, and skips any configuration if it evaluates to false. However, the code here depends on PHP_SAPI, resulting in an exception in environments where `PHP_SAPI === 'cli'`, but `consoleMode === false` (namely integration tests).

This PR unifies this behaviour and allows users to provide `%consoleMode%` in constructor as well, in a backward-compatible way.