### PR TITLE
Tracy: escape % in sql before vsprintf

### DIFF
--- a/src/Tracy/QueryPanel/QueryPanel.php
+++ b/src/Tracy/QueryPanel/QueryPanel.php
@@ -36,6 +36,9 @@ class QueryPanel extends AbstractLogger implements IBarPanel
 				// Do nothing
 			}
 
+			// Escape % before vsprintf (example: LIKE '%ant%')
+			$sql = str_replace('%', '%%', $sql);
+
 			$query = vsprintf(str_replace('?', '%s', $sql), call_user_func(function () use ($params, $types) {
 				$quotedParams = [];
 				foreach ($params as $typeIndex => $value) {


### PR DESCRIPTION
Hey,
This will fail:
`vsprintf('name LIKE "%filip%"', []);`

This will not
`echo vsprintf('name LIKE "%%filip%%"', []);`

Cheers