### PR TITLE
DbalExtension: allow specifying serverVersion

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,6 @@ includes:
 
 parameters:
 	ignoreErrors:
-		- '#^Cannot call method getMessage\(\) on Throwable\|null\.$#'
 		- "#^Parameter \\#1 \\$function of function call_user_func expects callable\\(\\): mixed, array\\(object, 'getSubscribedEvents'\\) given.#"
 		# No replacement available
 		- '#^Fetching class constant class of deprecated class Doctrine\\DBAL\\Tools\\Console\\Command\\ImportCommand\.$#'

--- a/src/DI/DbalExtension.php
+++ b/src/DI/DbalExtension.php
@@ -45,7 +45,6 @@ final class DbalExtension extends CompilerExtension
 			'host' => null,
 			'port' => null,
 			'dbname' => null,
-			'serverVersion' => null,
 			'servicename' => null,
 			'user' => null,
 			'password' => null,
@@ -118,7 +117,7 @@ final class DbalExtension extends CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 		$globalConfig = $this->validateConfig($this->defaults);
-		$config = $this->validateConfig($this->defaults['connection'], $this->config['connection']);
+		$config = $globalConfig['connection'];
 
 		$builder->addDefinition($this->prefix('eventManager'))
 			->setFactory(ContainerAwareEventManager::class);

--- a/src/DI/DbalExtension.php
+++ b/src/DI/DbalExtension.php
@@ -45,6 +45,7 @@ final class DbalExtension extends CompilerExtension
 			'host' => null,
 			'port' => null,
 			'dbname' => null,
+			'serverVersion' => null,
 			'servicename' => null,
 			'user' => null,
 			'password' => null,

--- a/tests/cases/DI/DbalExtensionTest.php
+++ b/tests/cases/DI/DbalExtensionTest.php
@@ -20,7 +20,7 @@ final class DbalExtensionTest extends TestCase
 		$loader = new ContainerLoader(TEMP_PATH, true);
 		$class = $loader->load(function (Compiler $compiler): void {
 			$compiler->addExtension('dbal', new DbalExtension());
-			$compiler->addConfig(['dbal' => ['connection' => ['driver' => 'pdo_sqlite']]]);
+			$compiler->addConfig(['dbal' => ['connection' => ['driver' => 'pdo_sqlite', 'foo' => 'bar']]]);
 		}, '1a');
 
 		/** @var Container $container */

--- a/tests/cases/DI/DbalExtensionTest.php
+++ b/tests/cases/DI/DbalExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Nettrine\DBAL\Cases\DI;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Nette\DI\Compiler;
 use Nette\DI\Container;
@@ -83,6 +84,24 @@ final class DbalExtensionTest extends TestCase
 		$connection = $container->getByType(Connection::class);
 
 		$this->assertInstanceOf(DebugEventManager::class, $connection->getEventManager());
+	}
+
+	public function testServerVersion(): void
+	{
+		$loader = new ContainerLoader(TEMP_PATH, true);
+		$class = $loader->load(function (Compiler $compiler): void {
+			$compiler->addExtension('dbal', new DbalExtension());
+			$compiler->addConfig(['dbal' => ['connection' => ['driver' => 'pdo_pgsql', 'serverVersion' => '10.0']]]);
+		}, '1c');
+
+		/** @var Container $container */
+		$container = new $class();
+
+		/** @var Connection $connection */
+		$connection = $container->getByType(Connection::class);
+
+		$this->assertInstanceOf(PostgreSQL100Platform::class, $connection->getDatabasePlatform());
+		$this->assertFalse($connection->isConnected());
 	}
 
 }


### PR DESCRIPTION
Allow static configuration of db server version, this in turns allows to resolve database platform without actually connecting to database. It is extremely useful in tests, static analysis, ...

Side note: it might be a good idea to completely turn off validation of parameters in `dbal.connection` section and let everything pass through. At the moment there are other "standard" parameters that cannot be set (e.g. `platform`), and the wrapper class might want to use even some "non-standard" parameters.