### PR TITLE
DbalExtension: fix for numeric service names being converted to integers

### DIFF
--- a/src/DI/DbalExtension.php
+++ b/src/DI/DbalExtension.php
@@ -153,6 +153,7 @@ final class DbalExtension extends CompilerExtension
 
 		$eventManager = $builder->getDefinition($this->prefix('eventManager'));
 		foreach ($builder->findByTag(self::TAG_NETTRINE_SUBSCRIBER) as $serviceName => $tag) {
+			$serviceName = (string) $serviceName; // nette/di 2.4 allows numeric names, which are converted to integers
 			$class = $builder->getDefinition($serviceName)->getType();
 
 			if ($class === null || !is_subclass_of($class, EventSubscriber::class)) {


### PR DESCRIPTION
PHP has this unfortunate "feature" of converting numeric array keys to integers, see https://3v4l.org/8pS7I

nette/di 2.4 names anonymous services by numeric keys and it kind of breaks the registration of subscribers to event manager, because it expects either string service name, or object. Add explicite type case to `DbalExtension` should fix the issue.

btw, nette/di 3.0 has a guard against numeric service names, so this is really for 2.4.x only