### PR TITLE
Fix typo in README.md

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -79,7 +79,7 @@ dbal:
         types:
             uuid_binary_ordered_time:
                 class: Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType
-                commented: falsee
+                commented: false
 
         typesMapping:
             uuid_binary_ordered_time: binary


### PR DESCRIPTION
Change "falsee" to "false" in types.uuid_binary_ordered_time.commented.