### PR TITLE
DbalExtension: requires cache configured

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -54,7 +54,7 @@ dbal:
         sourcePaths: [%appDir%]
     configuration:
         sqlLogger: NULL
-        resultCacheImpl: NULL
+        resultCache: NULL
         filterSchemaAssetsExpression: NULL
         autoCommit: TRUE
 

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,13 @@
   ],
   "require": {
     "php": "^7.2",
-    "nette/di": "~3.0.0",
+    "contributte/di": "^0.4.0",
     "doctrine/dbal": "^2.9.2"
   },
   "require-dev": {
     "contributte/console": "^0.5.0",
     "mockery/mockery": "^1.2.2",
+    "nettrine/cache": "^0.1.0",
     "ninjify/qa": "^0.9.0",
     "phpstan/extension-installer": "^1.0",
     "phpstan/phpstan-deprecation-rules": "^0.11.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,5 @@ parameters:
 		- "#^Parameter \\#1 \\$function of function call_user_func expects callable\\(\\): mixed, array\\(object, 'getSubscribedEvents'\\) given.#"
 		# No replacement available
 		- '#^Fetching class constant class of deprecated class Doctrine\\DBAL\\Tools\\Console\\Command\\ImportCommand.+#'
+		# Method iterates through property and converts string values to objects, cannot happen
+		- '#^Method Nettrine\\DBAL\\Events\\ContainerAwareEventManager\:\:getInitializedListeners\(\) should return array\<object\> but returns array\<object\|string\>\.$#'

--- a/src/Tracy/QueryPanel/templates/panel.phtml
+++ b/src/Tracy/QueryPanel/templates/panel.phtml
@@ -30,8 +30,9 @@ use Tracy\Helpers;
 	<h1>No queries</h1>
 <?php else: ?>
 	<h1>Queries:
-		<?= $queriesNum ?>
-		<?= $totalTime ? sprintf('%0.3f', $totalTime * 1000) : ''; ?>
+		<?= $queriesNum ?>,
+		time:
+		<?= $totalTime ? sprintf('%0.3f', $totalTime * 1000) : ''; ?> ms
 	</h1>
 <?php endif; ?>
 

--- a/tests/cases/Integration/QueryTest.php
+++ b/tests/cases/Integration/QueryTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Nette\DI\Compiler;
 use Nette\DI\Container;
 use Nette\DI\ContainerLoader;
+use Nettrine\Cache\DI\CacheExtension;
 use Nettrine\DBAL\DI\DbalExtension;
 use Tests\Toolkit\TestCase;
 use Tracy\Bridges\Nette\TracyExtension;
@@ -18,7 +19,13 @@ final class QueryTest extends TestCase
 		$loader = new ContainerLoader(TEMP_PATH, true);
 		$class = $loader->load(function (Compiler $compiler): void {
 			$compiler->addExtension('tracy', new TracyExtension());
+			$compiler->addExtension('cache', new CacheExtension());
 			$compiler->addExtension('dbal', new DbalExtension());
+			$compiler->addConfig([
+				'parameters' => [
+					'tempDir' => TEMP_PATH,
+				],
+			]);
 		}, 'int1');
 
 		/** @var Container $container */

--- a/tests/cases/Unit/Events/EventManagerTest.php
+++ b/tests/cases/Unit/Events/EventManagerTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Nette\DI\Compiler;
 use Nette\DI\Container;
 use Nette\DI\ContainerLoader;
+use Nettrine\Cache\DI\CacheExtension;
 use Nettrine\DBAL\DI\DbalExtension;
 use Tests\Fixtures\Subscriber\PostConnectSubscriber;
 use Tests\Toolkit\NeonLoader;
@@ -19,7 +20,13 @@ final class EventManagerTest extends TestCase
 	{
 		$loader = new ContainerLoader(TEMP_PATH, true);
 		$class = $loader->load(function (Compiler $compiler): void {
+			$compiler->addExtension('cache', new CacheExtension());
 			$compiler->addExtension('dbal', new DbalExtension());
+			$compiler->addConfig([
+				'parameters' => [
+					'tempDir' => TEMP_PATH,
+				],
+			]);
 			$compiler->addConfig(NeonLoader::load('
 			dbal:
 				connection:


### PR DESCRIPTION
DbalExtension
	- resultCacheImpl renamed to resultCache to be same as in Nettrine\Orm\DI\OrmCacheExtension
	- resultCache is always required and auto-configured by default (user may still explicitly use VoidCache class)
 	- resultCache and sqlLogger use flexible services configuration provided by contributte/di

Tracy
	- in title is displayed `time: 3.700 ms` instead of just `3.700` - closes #41 

ContainerAwareEventManager
	- always returns initialized services - closes #45 