### PR TITLE
Tracy: numerical sorting queries by time

### DIFF
--- a/src/Tracy/QueryPanel/templates/panel.phtml
+++ b/src/Tracy/QueryPanel/templates/panel.phtml
@@ -24,6 +24,10 @@ use Tracy\Helpers;
 		max-height: 150px;
 		overflow: auto
 	}
+
+	#tracy-debug .nettrine-dbal td > a.tracy-toggle::before {
+		content: 'source';
+	}
 </style>
 
 <?php if ($queriesNum === 0): ?>
@@ -49,7 +53,7 @@ use Tracy\Helpers;
 					<td>
 						<?= sprintf('%0.2f', $q->duration * 1000); ?>
 						<?php if (count($q->source) !== 0): ?>
-							<br><a class="tracy-toggle tracy-collapsed" data-tracy-ref="^tr .nettrine-dbal-backtrace">source</a>
+							<br><a class="tracy-toggle tracy-collapsed" data-tracy-ref="^tr .nettrine-dbal-backtrace"></a>
 						<?php endif; ?>
 					</td>
 					<td class="tracy-dbal-sql">


### PR DESCRIPTION
Sorting query table by time is broken (because of "source" link). E.g. following table should be sorted (I clicked on the "time" column header):

![image](https://user-images.githubusercontent.com/6796369/73141722-8f782600-4087-11ea-9871-5711478ab442.png)

This PR fixes that (by inserting the link text via CSS ::after+content).