### PR TITLE
Simplify types registration

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -141,12 +141,14 @@ Here is an example of how to register custom type for [UUID](https://github.com/
 dbal:
   connection:
     types:
+      uuid: Ramsey\Uuid\Doctrine\UuidType
+
       uuid_binary_ordered_time:
         class: Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType
         commented: false
 
-      typesMapping:
-        uuid_binary_ordered_time: binary
+    typesMapping:
+      uuid_binary_ordered_time: binary
 ```
 
 For more information about custom types, take a look at the official documention.

--- a/src/DI/DbalExtension.php
+++ b/src/DI/DbalExtension.php
@@ -44,11 +44,23 @@ final class DbalExtension extends CompilerExtension
 				'filterSchemaAssetsExpression' => Expect::string()->nullable(),
 				'autoCommit' => Expect::bool(true),
 			]),
-			'connection' => Expect::array()->default([
-				'driver' => 'pdo_sqlite',
-				'types' => [],
-				'typesMapping' => [],
-			]),
+			'connection' => Expect::structure([
+				'driver' => Expect::mixed('pdo_sqlite'),
+				'types' => Expect::arrayOf(
+					Expect::structure([
+						'class' => Expect::string()->required(),
+						'commented' => Expect::bool(false),
+					])
+						->before(function ($type) {
+							if (is_string($type)) {
+								return ['class' => $type];
+							}
+							return $type;
+						})
+						->castTo('array')
+				),
+				'typesMapping' => Expect::array(),
+			])->otherItems()->castTo('array'),
 		]);
 	}
 


### PR DESCRIPTION
The current registration of custom types seems to be unnecessarily complicated. This PR introduces two changes that simplify the whole configuration:
1) Allows omit `commented` type field (defaults to `false`). This configuration is in most cases not really needed, the feature is usually toggled directly by type definition, see `Type::requiresSQLCommentHint()`.
2) It allows a short-hand configuration syntax `typeName: TypeClass`, which is equal to `typeName: {class: TypeClass}`