### PR TITLE
ProfilerLogger: Fix errors in DBAL 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,10 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": false
+    }
   },
   "extra": {
     "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -56,10 +56,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {
-    "sort-packages": true,
-    "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": false
-    }
+    "sort-packages": true
   },
   "extra": {
     "branch-alias": {

--- a/src/Logger/ProfilerLogger.php
+++ b/src/Logger/ProfilerLogger.php
@@ -57,7 +57,7 @@ class ProfilerLogger extends AbstractLogger
 					$quotedParams = [];
 					foreach ($params as $typeIndex => $value) {
 						$type = $types[$typeIndex] ?? null;
-						$quotedParams[] = $this->getConnection()->quote($value, $type);
+						$quotedParams[] = $value === null ? $value : $this->getConnection()->quote($value, $type);
 					}
 
 					return $quotedParams;
@@ -86,7 +86,7 @@ class ProfilerLogger extends AbstractLogger
 		}
 
 		$parser = $this->getConnection()->getDatabasePlatform()->createSQLParser();
-		$visitor = new ExpandArrayParameters($params, $types);
+		$visitor = new ExpandArrayParameters(array_values($params), array_values($types));
 		$parser->parse($query, $visitor);
 
 		return [

--- a/src/Logger/ProfilerLogger.php
+++ b/src/Logger/ProfilerLogger.php
@@ -91,6 +91,7 @@ class ProfilerLogger extends AbstractLogger
 		} else {
 			$visitor = new ExpandArrayParameters($params, $types);
 		}
+
 		$parser->parse($query, $visitor);
 
 		return [

--- a/src/Logger/ProfilerLogger.php
+++ b/src/Logger/ProfilerLogger.php
@@ -86,7 +86,7 @@ class ProfilerLogger extends AbstractLogger
 
 		if ($this->olderDbalVersion) { // DBAL 2.x compatibility
 			try {
-				return SQLParserUtils::expandListParameters($query, $params, $types);
+				return SQLParserUtils::expandListParameters($query, $params, $types); /** @phpstan-ignore-line */
 			} catch (Throwable $e) {
 				return [$query, $params, $types];
 			}

--- a/src/Logger/ProfilerLogger.php
+++ b/src/Logger/ProfilerLogger.php
@@ -12,6 +12,9 @@ use Throwable;
 class ProfilerLogger extends AbstractLogger
 {
 
+	/** @var ?bool */
+	private $olderDbalVersion = null;
+
 	/** @var ConnectionAccessor */
 	protected $connectionAccessor;
 
@@ -77,7 +80,11 @@ class ProfilerLogger extends AbstractLogger
 	 */
 	private function expandListParameters(string $query, array $params, array $types): array
 	{
-		if (class_exists(SQLParserUtils::class)) { // DBAL 2.x compatibility
+		if ($this->olderDbalVersion === null) {
+			$this->olderDbalVersion = class_exists(SQLParserUtils::class);
+		}
+
+		if ($this->olderDbalVersion) { // DBAL 2.x compatibility
 			try {
 				return SQLParserUtils::expandListParameters($query, $params, $types);
 			} catch (Throwable $e) {

--- a/src/Logger/ProfilerLogger.php
+++ b/src/Logger/ProfilerLogger.php
@@ -86,7 +86,11 @@ class ProfilerLogger extends AbstractLogger
 		}
 
 		$parser = $this->getConnection()->getDatabasePlatform()->createSQLParser();
-		$visitor = new ExpandArrayParameters(array_values($params), array_values($types));
+		if (is_int(key($params))) { // Positional parameters, checked same as 2.x SQLParserUtils.php:88
+			$visitor = new ExpandArrayParameters(array_values($params), array_values($types)); // ExpandArrayParameters has starting index at 0, flushing new entities at 1
+		} else {
+			$visitor = new ExpandArrayParameters($params, $types);
+		}
 		$parser->parse($query, $visitor);
 
 		return [

--- a/tests/cases/E2E/ProfilerLoggerTest.php
+++ b/tests/cases/E2E/ProfilerLoggerTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\E2E;
+
+use Doctrine\DBAL\Connection;
+use Nette\DI\Compiler;
+use Nette\DI\Container;
+use Nette\DI\ContainerLoader;
+use Nettrine\Cache\DI\CacheExtension;
+use Nettrine\DBAL\ConnectionAccessor;
+use Nettrine\DBAL\DI\DbalExtension;
+use Nettrine\DBAL\Logger\ProfilerLogger;
+use Ninjify\Nunjuck\Toolkit;
+use Tester\Assert;
+use Tests\Toolkit\DoctrineDeprecations;
+use Tests\Toolkit\NeonLoader;
+use Tracy\Bridges\Nette\TracyExtension;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+Toolkit::test(function (): void {
+	// Ignore deprecations that are impossible to fix while keeping DBAL 2.x support
+	DoctrineDeprecations::ignoreDeprecations(
+		'https://github.com/doctrine/dbal/pull/4967',
+		'https://github.com/doctrine/dbal/pull/4620',
+		'https://github.com/doctrine/dbal/pull/4578'
+	);
+
+	$loader = new ContainerLoader(TEMP_DIR, true);
+	$class = $loader->load(function (Compiler $compiler): void {
+		$compiler->addExtension('tracy', new TracyExtension());
+		$compiler->addExtension('cache', new CacheExtension());
+		$compiler->addExtension('dbal', new DbalExtension());
+		$compiler->addConfig(NeonLoader::load('
+			dbal:
+				connection:
+					driver: pdo_sqlite
+			'));
+		$compiler->addConfig([
+			'parameters' => [
+				'tempDir' => TMP_DIR,
+			],
+		]);
+	}, __FILE__ . '1');
+
+	/** @var Container $container */
+	$container = new $class();
+
+	/** @var Connection $connection */
+	$connection = $container->getByType(Connection::class);
+
+	$connection->getConfiguration()->setSQLLogger(new ProfilerLogger($container->getByType(ConnectionAccessor::class)));
+
+	Assert::noError(function () use ($connection) {
+		// Orm insert queries have starting index 1, if ExpandArrayParameters would use parameters, it would throw an exception
+		$connection->getConfiguration()->getSQLLogger()->startQuery('INSERT INTO person (id, lastname, firstname) VALUES (?, ?, ?)', [
+			1 => 1,
+			2 => 'John',
+			3 => 'Doe',
+		]);
+	});
+
+	Assert::noError(function () use ($connection) {
+		$connection->getConfiguration()->getSQLLogger()->startQuery('UPDATE person SET firstname = ?, lastname = ?', [
+			0 => 'John',
+			1 => 'Doe',
+		]);
+	});
+});

--- a/tests/cases/E2E/ProfilerLoggerTest.php
+++ b/tests/cases/E2E/ProfilerLoggerTest.php
@@ -14,7 +14,6 @@ use Ninjify\Nunjuck\Toolkit;
 use Tester\Assert;
 use Tests\Toolkit\DoctrineDeprecations;
 use Tests\Toolkit\NeonLoader;
-use Tracy\Bridges\Nette\TracyExtension;
 
 require_once __DIR__ . '/../../bootstrap.php';
 
@@ -28,7 +27,6 @@ Toolkit::test(function (): void {
 
 	$loader = new ContainerLoader(TEMP_DIR, true);
 	$class = $loader->load(function (Compiler $compiler): void {
-		$compiler->addExtension('tracy', new TracyExtension());
 		$compiler->addExtension('cache', new CacheExtension());
 		$compiler->addExtension('dbal', new DbalExtension());
 		$compiler->addConfig(NeonLoader::load('


### PR DESCRIPTION
When persisting and flushing entity, there was an error

```
Doctrine\DBAL\ArrayParameters\Exception\MissingPositionalParameter: Positional parameter at index 0 does not have a bound value. in /vendor/doctrine/dbal/src/ArrayParameters/Exception/MissingPositionalParameter.php:19
Stack trace:
#0 /vendor/doctrine/dbal/src/ExpandArrayParameters.php(51): Doctrine\DBAL\ArrayParameters\Exception\MissingPositionalParameter::new(0)
#1 /vendor/doctrine/dbal/src/SQL/Parser.php(89): Doctrine\DBAL\ExpandArrayParameters->acceptPositionalParameter('...')
#2 /vendor/doctrine/dbal/src/SQL/Parser.php(103): Doctrine\DBAL\SQL\Parser::Doctrine\DBAL\SQL\{closure}('...')
#3 /vendor/nettrine/dbal/src/Logger/ProfilerLogger.php(90): Doctrine\DBAL\SQL\Parser->parse('...', Object(Doctrine\DBAL\ExpandArrayParameters))
#4 /vendor/nettrine/dbal/src/Logger/ProfilerLogger.php(49): Nettrine\DBAL\Logger\ProfilerLogger->expandListParameters('...', Array, Array)
#5 /vendor/doctrine/dbal/src/Logging/LoggerChain.php(37): Nettrine\DBAL\Logger\ProfilerLogger->startQuery('...', Array, Array)
#6 /vendor/doctrine/dbal/src/Statement.php(175): Doctrine\DBAL\Logging\LoggerChain->startQuery('...', Array, Array)
#7 /vendor/doctrine/dbal/src/Statement.php(221): Doctrine\DBAL\Statement->execute(NULL)
#8 /vendor/doctrine/orm/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php(278): Doctrine\DBAL\Statement->executeStatement()
#9 /vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php(1129): Doctrine\ORM\Persisters\Entity\BasicEntityPersister->executeInserts()
#10 /vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php(426): Doctrine\ORM\UnitOfWork->executeInserts(Object(Doctrine\ORM\Mapping\ClassMetadata))
#11 /vendor/doctrine/orm/lib/Doctrine/ORM/EntityManager.php(398): Doctrine\ORM\UnitOfWork->commit(NULL)
#12 /vendor/doctrine/orm/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php(211): Doctrine\ORM\EntityManager->flush(NULL)
```

So I found that in `ExpandArrayParameters::acceptPositionalParameter` was $index = 0 and first index of `$this->originalParameters` started always from 1, not 0

```php
    public function acceptPositionalParameter(string $sql): void
    {
        $index = $this->originalParameterIndex;
		
        if (! array_key_exists($index, $this->originalParameters)) {
            throw MissingPositionalParameter::new($index);
        }

        $this->acceptParameter($index, $this->originalParameters[$index]);

        $this->originalParameterIndex++;
    }
```

Using array_values should resolve the problem, I have tested it on PHP 8.1 and it works just fine.
Also, after resolving the problem there appeared a new one, null value was passed to non-null argument, so I have added a nullcheck.