### PR TITLE
Fix PHP 8.1 deprecation error

### DIFF
--- a/src/Logger/ProfilerLogger.php
+++ b/src/Logger/ProfilerLogger.php
@@ -59,7 +59,7 @@ class ProfilerLogger extends AbstractLogger
 					$quotedParams = [];
 					foreach ($params as $typeIndex => $value) {
 						$type = $types[$typeIndex] ?? null;
-						$quotedParams[] = $this->connection->quote($value, $type);
+						$quotedParams[] = $value === null ? $value : $this->connection->quote($value, $type);
 					}
 
 					return $quotedParams;


### PR DESCRIPTION
Fixes PDO::quote(): Passing null to parameter #1 ($string) of type string is deprecated