### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,5 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.3"


### PR DESCRIPTION
## What changed

- added `secrets: inherit` to `.github/workflows/coverage.yml` so the reusable coverage workflow receives repository secrets from this caller

## Why

- aligns this repository with the issue 74 rollout so coverage jobs can access the required secrets when invoking the shared workflow
- relates to contributte/contributte#74